### PR TITLE
Fix UI Order Bug

### DIFF
--- a/game/project.hpp
+++ b/game/project.hpp
@@ -12,39 +12,39 @@
 class Project : public UIScreen
 {
 public:
-  WorldRenderScreen *world_render;
-  WorldNavigationGUI::Screen *world_navigation_gui;
-  InventoryGUI::Screen *inventory_gui;
-  StartScreenGUI::Screen *start_screen_gui;
+   WorldRenderScreen *world_render;
+   WorldNavigationGUI::Screen *world_navigation_gui;
+   InventoryGUI::Screen *inventory_gui;
+   StartScreenGUI::Screen *start_screen_gui;
 
-  Project(Display *display)
-    : UIScreen(display)
-    , world_render(new WorldRenderScreen(display))
-    , world_navigation_gui(new WorldNavigationGUI::Screen(this, display))
-    , inventory_gui(new InventoryGUI::Screen(display))
-    , start_screen_gui(new StartScreenGUI::Screen(this, display))
-  {
-    // link nav render surface
-    world_render->set_scene_targets_render_surface(world_navigation_gui->nav_view->render);
+   Project(Display *display)
+      : UIScreen(display)
+      , world_render(new WorldRenderScreen(display))
+      , world_navigation_gui(new WorldNavigationGUI::Screen(this, display))
+      , inventory_gui(new InventoryGUI::Screen(display))
+      , start_screen_gui(new StartScreenGUI::Screen(this, display))
+   {
+      // link nav render surface
+      world_render->set_scene_targets_render_surface(world_navigation_gui->nav_view->render);
 
-    ScriptHelper::initialize(world_render, world_navigation_gui, inventory_gui, start_screen_gui);
+      ScriptHelper::initialize(world_render, world_navigation_gui, inventory_gui, start_screen_gui);
 
-    Script::run("StartTitleScreen()");
-  }
-  void on_message(UIWidget *sender, std::string message)
-  {
-    std::string trigger_id = "";
-    int unique_trigger_id = 0;
-    if (TargetID::extract_trigger_id(message, &trigger_id))
-    {
-      std::cout << "Project running script \"" << trigger_id << "\"" << std::endl;
-      Script::run(trigger_id);
-    }
-    else if (TargetID::extract_unique_trigger_id(message, &unique_trigger_id))
-    {
-      if (Logging::at_least(L_VERBOSE)) std::cout << "Project running script ID\"" << unique_trigger_id << "\"" << std::endl;
-      Script::run_by_unique_id(unique_trigger_id);
-    }
-  }
+      Script::run("StartTitleScreen()");
+   }
+   void on_message(UIWidget *sender, std::string message)
+   {
+      std::string trigger_id = "";
+      int unique_trigger_id = 0;
+      if (TargetID::extract_trigger_id(message, &trigger_id))
+      {
+         std::cout << "Project running script \"" << trigger_id << "\"" << std::endl;
+         Script::run(trigger_id);
+      }
+      else if (TargetID::extract_unique_trigger_id(message, &unique_trigger_id))
+      {
+         if (Logging::at_least(L_VERBOSE)) std::cout << "Project running script ID\"" << unique_trigger_id << "\"" << std::endl;
+         Script::run_by_unique_id(unique_trigger_id);
+      }
+   }
 };
 

--- a/game/script_helper.hpp
+++ b/game/script_helper.hpp
@@ -134,6 +134,8 @@ public:
     , std::string right_target
     )
   {
+    world_navigation_gui->set_usability_mode(0);
+
     world_navigation_gui->nav_up_button->set_target_id(TargetID(up_target));
     world_navigation_gui->nav_down_button->set_target_id(TargetID(down_target));
     world_navigation_gui->nav_left_button->set_target_id(TargetID(left_target));
@@ -152,29 +154,6 @@ public:
     e->place.rotation.y = rotation;
 
     return e;
-  }
-  static void set_nav
-    ( std::string up_target_num
-    , std::string down_target_num
-    , std::string left_target_num
-    , std::string right_target_num
-    )
-  {
-    world_navigation_gui->set_usability_mode(0);
-
-    std::string up = (up_target_num.empty() ? "" : (tostring("goto") + up_target_num));
-    world_navigation_gui->nav_up_button->set_target_id(TargetID(up));
-
-    std::string down = (down_target_num.empty() ? "" : (tostring("goto") + down_target_num));
-    world_navigation_gui->nav_down_button->set_target_id(TargetID(down));
-
-    std::string left = (left_target_num.empty() ? "" : (tostring("goto") + left_target_num));
-    world_navigation_gui->nav_left_button->set_target_id(TargetID(left));
-
-    std::string right = (right_target_num.empty() ? "" : (tostring("goto") + right_target_num));
-    world_navigation_gui->nav_right_button->set_target_id(TargetID(right));
-
-    world_navigation_gui->set_usability_mode(1);
   }
   static void initialize(
       WorldRenderScreen *wrs,

--- a/game/scripts/gotos.hpp
+++ b/game/scripts/gotos.hpp
@@ -9,7 +9,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(0, 0, 0.25);
-      set_nav("", "", "5", "2");
+      set_nav_buttons("", "", "goto5", "goto2");
 
       attach("MainDoorDoor", "goto18");
    }
@@ -25,7 +25,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(0, 0, 0.124);
-      set_nav("", "", "1", "3");
+      set_nav_buttons("", "", "goto1", "goto3");
    }
 };
 
@@ -39,7 +39,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(0, 0, 0.9);
-      set_nav("", "", "2", "4");
+      set_nav_buttons("", "", "goto2", "goto4");
    }
 };
 
@@ -53,7 +53,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(0, 0, 0.7);
-      set_nav("", "", "3", "5");
+      set_nav_buttons("", "", "goto3", "goto5");
 
       attach("EncryptedCardKey", "PickupEncryptedCardKey");
       attach("SnowPoster", "goto23");
@@ -70,7 +70,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(0, 0, 0.5);
-      set_nav("", "", "4", "1");
+      set_nav_buttons("", "", "goto4", "goto1");
 
       attach("PoetryPoster", "goto8");
    }
@@ -86,7 +86,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(0, 24, 0.45);
-      set_nav("", "5", "", "");
+      set_nav_buttons("", "goto5", "", "");
 
       attach("CardKeyDecrypter", "PickupCardKeyDecrypter");
    }
@@ -104,7 +104,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(-7, 0, 0.25);
-      set_nav("", "1", "", "");
+      set_nav_buttons("", "goto1", "", "");
 
       attach("MainDoorTerminal", "OpenMainDoor");
    }
@@ -120,7 +120,7 @@ public:
    {
       clear_attached_scripts();
       simple_camera_to(16, 0, 0.75);
-      set_nav("", "4", "", "");
+      set_nav_buttons("", "goto4", "", "");
    }
 };
 

--- a/include/inventory_gui/screen.hpp
+++ b/include/inventory_gui/screen.hpp
@@ -31,7 +31,7 @@ namespace InventoryGUI
 
       Screen(Display *display);
 
-      void on_message(UIWidget *sender, std::string message);
+      void on_message(UIWidget *sender, std::string message) override;
       bool symmetric_yes(InventoryItem itemA, InventoryItem itemB, InventoryItem::Type type1, InventoryItem::Type type2);
       InventoryItem attempt_combination(InventoryItem itemA, InventoryItem itemB);
       bool has_item(InventoryItem::Type item_type);

--- a/src/inventory_gui/screen.cpp
+++ b/src/inventory_gui/screen.cpp
@@ -22,17 +22,18 @@ InventoryGUI::Screen::Screen(Display *display)
    , item_buttons()
    , current_mode(1)
 {
-   // create our Inventory GUI Widgets
-   behind_blocker = new InventoryGUI::BehindBlocker(this);
-   toggle_button = new InventoryGUI::InventoryToggleButton(this);
-   current_item_showcase = new InventoryGUI::CurrentItemShowcase(this);
    notification = new InventoryGUI::Notification(this);
 
+   // create our Inventory GUI Widgets
    for (unsigned i=0; i<NUM_INVENTORY_ITEM_BUTTONS; i++)
    {
       InventoryGUI::ItemButton *button = new InventoryGUI::ItemButton(this, SCREEN_W-100, 200+90*i);
       item_buttons.push_back(button);
    }
+
+   current_item_showcase = new InventoryGUI::CurrentItemShowcase(this);
+   toggle_button = new InventoryGUI::InventoryToggleButton(this);
+   behind_blocker = new InventoryGUI::BehindBlocker(this);
 
    // set our current GUI mode
    set_visibility_mode(current_mode);

--- a/src/world_navigation_gui/nav_view.cpp
+++ b/src/world_navigation_gui/nav_view.cpp
@@ -59,6 +59,7 @@ void WorldNavigationGUI::NavView::on_click()
 
 void WorldNavigationGUI::NavView::on_draw()
 {
+   return;
    al_draw_rectangle(0, 0, place.size.x, place.size.y, color::green, 8);
    al_draw_filled_rectangle(0, 0, place.size.x, place.size.y, color::mix(color::red, color::transparent, 0.4));
    al_draw_bitmap(render, 0, 0, 0);


### PR DESCRIPTION
### Problem

Somehow, UI Elements were being created in reverse order, causing the `BehindBlocker` to block the buttons behind it.

### Solution

Re-order the created objects.  (https://github.com/MarkOates/the-path-beyond/pull/5/commits/3010652579627a724c095e8305d1ca005fc903c8)

This PR also includes some other smaller fixes, too.